### PR TITLE
Add basic Laravel + React skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Node artifacts
+node_modules/
+dist/
+
+# PHP Composer artifacts
+vendor/
+
+# Environment files
+.env
+
+# Logs
+*.log

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# HOI4 Modding Interface
+
+This repository contains a very lightweight structure for building a HOI4 modding interface.
+
+- `frontend` – a React (Vite) based single page application.
+- `backend` – a Laravel compatible API using MySQL.
+
+These folders are intentionally minimal so they can be expanded locally by running `npm install` and `composer install` if desired.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,14 @@
+APP_NAME=HOI4Modding
+APP_ENV=local
+APP_KEY=
+APP_DEBUG=true
+APP_URL=http://localhost
+
+LOG_CHANNEL=stack
+
+DB_CONNECTION=mysql
+DB_HOST=127.0.0.1
+DB_PORT=3306
+DB_DATABASE=hoi4modding
+DB_USERNAME=root
+DB_PASSWORD=

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,3 @@
+# Backend (Laravel Skeleton)
+
+This folder contains a minimal Laravel-compatible structure. Run `composer install` and `php artisan migrate` after configuring `.env` with your MySQL credentials to get started.

--- a/backend/app/Models/Country.php
+++ b/backend/app/Models/Country.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Country extends Model
+{
+    protected $fillable = [
+        'tag',
+        'name',
+        'ideology',
+    ];
+
+    public function focusTrees()
+    {
+        return $this->hasMany(FocusTree::class);
+    }
+
+    public function gameEvents()
+    {
+        return $this->hasMany(GameEvent::class);
+    }
+}

--- a/backend/app/Models/FocusTree.php
+++ b/backend/app/Models/FocusTree.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class FocusTree extends Model
+{
+    protected $fillable = [
+        'name',
+        'country_id',
+    ];
+
+    public function country()
+    {
+        return $this->belongsTo(Country::class);
+    }
+}

--- a/backend/app/Models/GameEvent.php
+++ b/backend/app/Models/GameEvent.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class GameEvent extends Model
+{
+    protected $fillable = [
+        'title',
+        'description',
+        'country_id',
+    ];
+
+    public function country()
+    {
+        return $this->belongsTo(Country::class);
+    }
+}

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -1,0 +1,13 @@
+{
+  "name": "hoi4modding/backend",
+  "type": "project",
+  "require": {
+    "php": "^8.1",
+    "laravel/framework": "^10.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "App\\": "app/"
+    }
+  }
+}

--- a/backend/database/migrations/2025_01_01_000001_create_countries_table.php
+++ b/backend/database/migrations/2025_01_01_000001_create_countries_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up()
+    {
+        Schema::create('countries', function (Blueprint $table) {
+            $table->id();
+            $table->string('tag')->unique();
+            $table->string('name');
+            $table->string('ideology')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('countries');
+    }
+};

--- a/backend/database/migrations/2025_01_01_000002_create_focus_trees_table.php
+++ b/backend/database/migrations/2025_01_01_000002_create_focus_trees_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up()
+    {
+        Schema::create('focus_trees', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->foreignId('country_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('focus_trees');
+    }
+};

--- a/backend/database/migrations/2025_01_01_000003_create_game_events_table.php
+++ b/backend/database/migrations/2025_01_01_000003_create_game_events_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up()
+    {
+        Schema::create('game_events', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->text('description')->nullable();
+            $table->foreignId('country_id')->nullable()->constrained()->nullOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('game_events');
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -1,0 +1,9 @@
+<?php
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use App\Models\Country;
+
+Route::get('/countries', fn () => Country::all());
+Route::get('/countries/{country}/focus-trees', fn (Country $country) => $country->focusTrees);
+Route::get('/countries/{country}/events', fn (Country $country) => $country->gameEvents);

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,8 @@
+# Frontend (React + Vite)
+
+To start development:
+
+```bash
+npm install
+npm run dev
+```

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>HOI4 Modding</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "hoi4modding-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.3.9"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function App() {
+  return (
+    <div>
+      <h1>HOI4 Modding Interface</h1>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- scaffold a React (Vite) frontend
- scaffold a Laravel-style backend with MySQL config
- add example models and migrations for countries, focus trees and events
- include minimal routes and environment template

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850521f6e248327b64fa02e1fd4dcbc