### PR TITLE
Add create mod API and form

### DIFF
--- a/gui_back/app/Http/Controllers/ModController.php
+++ b/gui_back/app/Http/Controllers/ModController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Mod;
+use Illuminate\Http\Request;
+
+class ModController extends Controller
+{
+    public function index()
+    {
+        return Mod::all();
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'name' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'version' => 'nullable|string|max:50',
+        ]);
+
+        $mod = Mod::create($validated);
+
+        return response()->json($mod, 201);
+    }
+}

--- a/gui_back/app/Models/Mod.php
+++ b/gui_back/app/Models/Mod.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Mod extends Model
+{
+    protected $fillable = [
+        'name',
+        'description',
+        'version'
+    ];
+}

--- a/gui_back/database/migrations/2025_06_16_180000_create_mods_table.php
+++ b/gui_back/database/migrations/2025_06_16_180000_create_mods_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('mods', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->string('version')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('mods');
+    }
+};

--- a/gui_back/database/seeders/DatabaseSeeder.php
+++ b/gui_back/database/seeders/DatabaseSeeder.php
@@ -47,6 +47,14 @@ class DatabaseSeeder extends Seeder
             'original_url' => 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTVyiGFYIoPgISVR15LFQN1ZU054xBxfkHOfA&s',
         ]);
 
+        DB::table('mods')->insert([
+            'name' => 'Test Mod',
+            'description' => 'Example mod seeded for development.',
+            'version' => '0.1.0',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
 
 
     }

--- a/gui_back/resources/js/app.js
+++ b/gui_back/resources/js/app.js
@@ -1,15 +1,14 @@
 import './bootstrap';
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import ModList from './components/ModList';
 
-import React from 'react'
-import Budoske from './components/Budoske';
+const root = document.getElementById('app');
 
-function app() {
-  return (
-    <>
-      <div>app papap papaodia  p opdwidoew  őpp őoewőp wepő</div>
-      <Budoske></Budoske>
-    </>
-  )
+if (root) {
+    ReactDOM.createRoot(root).render(
+        <React.StrictMode>
+            <ModList />
+        </React.StrictMode>
+    );
 }
-
-export default app

--- a/gui_back/resources/js/components/CreateModForm.js
+++ b/gui_back/resources/js/components/CreateModForm.js
@@ -1,0 +1,62 @@
+import React, { useState } from 'react';
+import myAxios from '../axios';
+
+function CreateModForm({ onCreated }) {
+  const [form, setForm] = useState({ name: '', description: '', version: '' });
+  const [error, setError] = useState(null);
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    setError(null);
+    myAxios.post('/mods', form)
+      .then(res => {
+        if (onCreated) onCreated(res.data);
+        setForm({ name: '', description: '', version: '' });
+      })
+      .catch(err => {
+        console.error(err);
+        setError('Failed to create mod');
+      });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      <div>
+        <label>Name</label>
+        <input
+          name="name"
+          value={form.name}
+          onChange={handleChange}
+          required
+          className="border px-2"
+        />
+      </div>
+      <div>
+        <label>Description</label>
+        <textarea
+          name="description"
+          value={form.description}
+          onChange={handleChange}
+          className="border px-2"
+        ></textarea>
+      </div>
+      <div>
+        <label>Version</label>
+        <input
+          name="version"
+          value={form.version}
+          onChange={handleChange}
+          className="border px-2"
+        />
+      </div>
+      {error && <p className="text-red-500">{error}</p>}
+      <button type="submit" className="px-4 py-1 bg-blue-500 text-white">Create Mod</button>
+    </form>
+  );
+}
+
+export default CreateModForm;

--- a/gui_back/resources/js/components/ModList.js
+++ b/gui_back/resources/js/components/ModList.js
@@ -1,0 +1,38 @@
+import React, { useEffect, useState } from 'react';
+import myAxios from '../axios';
+import CreateModForm from './CreateModForm';
+
+function ModList() {
+  const [mods, setMods] = useState([]);
+
+  const fetchMods = () => {
+    myAxios.get('/mods-all')
+      .then(res => setMods(res.data))
+      .catch(err => console.error(err));
+  };
+
+  useEffect(() => {
+    fetchMods();
+  }, []);
+
+  const handleCreated = (mod) => {
+    setMods(prev => [...prev, mod]);
+  };
+
+  return (
+    <div>
+      <h2>Mods</h2>
+      <CreateModForm onCreated={handleCreated} />
+      <ul>
+        {mods.map(mod => (
+          <li key={mod.id}>
+            <strong>{mod.name}</strong> - {mod.version}
+            <p>{mod.description}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default ModList;

--- a/gui_back/resources/views/welcome.blade.php
+++ b/gui_back/resources/views/welcome.blade.php
@@ -20,6 +20,7 @@
         @endif
     </head>
     <body class="bg-[#FDFDFC] dark:bg-[#0a0a0a] text-[#1b1b18] flex p-6 lg:p-8 items-center lg:justify-center min-h-screen flex-col">
+        <div id="app"></div>
         <header class="w-full lg:max-w-4xl max-w-[335px] text-sm mb-6 not-has-[nav]:hidden">
             @if (Route::has('login'))
                 <nav class="flex items-center justify-end gap-4">

--- a/gui_back/routes/api.php
+++ b/gui_back/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\MediaController;
+use App\Http\Controllers\ModController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -9,5 +10,8 @@ Route::get('/user', function (Request $request) {
 })->middleware('auth:sanctum');
 
 Route::get("/medias-all", [MediaController::class, "index"]);
+
+Route::get('/mods-all', [ModController::class, 'index']);
+Route::post('/mods', [ModController::class, 'store']);
 
 


### PR DESCRIPTION
## Summary
- expand `ModController` with POST endpoint to create mods
- add `CreateModForm` React component
- list new form in `ModList` component
- expose POST `/mods` route

## Testing
- `node --version`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6851a51d2a508327a01bc653cc153d2a