### PR TITLE
Add mod listing interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # HOI4 Modding Interface
 
 This repository contains a very lightweight structure for building a HOI4 modding interface.
+The root `index.html` now includes a simple interface that fetches and displays
+a list of mods from the Laravel API.
 
 - `frontend` – a React (Vite) based single page application.
 - `backend` – a Laravel compatible API using MySQL.

--- a/index.html
+++ b/index.html
@@ -2,9 +2,51 @@
 <html lang="hu">
 <head>
   <meta charset="UTF-8">
-  <title>Hello World</title>
+  <title>HOI4 Modding Interface</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      padding: 20px;
+      background-color: #f5f5f5;
+    }
+
+    .mod-list {
+      margin-top: 20px;
+    }
+
+    .mod-item {
+      background: #fff;
+      padding: 10px;
+      margin-bottom: 10px;
+      border-radius: 4px;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    }
+
+    .mod-item h3 {
+      margin: 0 0 5px;
+    }
+  </style>
 </head>
 <body>
-  <h1>Hello World</h1>
+  <h1>HOI4 Mods</h1>
+  <div id="mods" class="mod-list"></div>
+  <script>
+    fetch('/api/mods-all')
+      .then(res => res.json())
+      .then(mods => {
+        const container = document.getElementById('mods');
+        mods.forEach(mod => {
+          const div = document.createElement('div');
+          div.className = 'mod-item';
+          div.innerHTML = `<h3>${mod.name} <small>${mod.version ? mod.version : ''}</small></h3>` +
+            `<p>${mod.description ? mod.description : ''}</p>`;
+          container.appendChild(div);
+        });
+      })
+      .catch(err => {
+        document.getElementById('mods').textContent = 'Failed to load mods.';
+        console.error('Error loading mods', err);
+      });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- make the landing page fetch and display mods from the backend
- document the new behaviour in README

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851aacf4ba8832788a7e826aa4a65b4