### PR TITLE
Add mod creation form and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 This repository contains a very lightweight structure for building a HOI4 modding interface.
 The root `index.html` now includes a simple interface that fetches and displays
-a list of mods from the Laravel API.
+a list of mods from the Laravel API. You can also add new mods through a
+minimal form that submits data back to the backend API.
 
 - `frontend` – a React (Vite) based single page application.
 - `backend` – a Laravel compatible API using MySQL.

--- a/gui_back/app/Http/Controllers/ModController.php
+++ b/gui_back/app/Http/Controllers/ModController.php
@@ -3,11 +3,25 @@
 namespace App\Http\Controllers;
 
 use App\Models\Mod;
+use Illuminate\Http\Request;
 
 class ModController extends Controller
 {
     public function index()
     {
         return Mod::all();
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'version' => 'nullable|string|max:50',
+        ]);
+
+        $mod = Mod::create($data);
+
+        return response()->json($mod, 201);
     }
 }

--- a/gui_back/routes/api.php
+++ b/gui_back/routes/api.php
@@ -12,5 +12,6 @@ Route::get('/user', function (Request $request) {
 Route::get("/medias-all", [MediaController::class, "index"]);
 
 Route::get('/mods-all', [ModController::class, 'index']);
+Route::post('/mods', [ModController::class, 'store']);
 
 

--- a/index.html
+++ b/index.html
@@ -10,6 +10,40 @@
       background-color: #f5f5f5;
     }
 
+    nav {
+      background: #1e3a8a;
+      padding: 10px;
+      margin-bottom: 20px;
+    }
+
+    nav a {
+      color: #fff;
+      margin-right: 15px;
+      text-decoration: none;
+      font-weight: bold;
+    }
+
+    h1 {
+      margin-top: 0;
+    }
+
+    form {
+      background: #fff;
+      padding: 15px;
+      border-radius: 4px;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+      margin-bottom: 20px;
+    }
+
+    form input, form textarea {
+      width: 100%;
+      padding: 8px;
+      margin-bottom: 10px;
+      border: 1px solid #ddd;
+      border-radius: 4px;
+      box-sizing: border-box;
+    }
+
     .mod-list {
       margin-top: 20px;
     }
@@ -28,25 +62,69 @@
   </style>
 </head>
 <body>
-  <h1>HOI4 Mods</h1>
+  <nav>
+    <a href="#">Home</a>
+    <a href="#mods">Mods</a>
+  </nav>
+  <h1>HOI4 Modding Interface</h1>
+
+  <form id="mod-form">
+    <h2>Add New Mod</h2>
+    <input type="text" id="name" placeholder="Name" required>
+    <input type="text" id="version" placeholder="Version">
+    <textarea id="description" placeholder="Description"></textarea>
+    <button type="submit">Add Mod</button>
+  </form>
+
+  <h2>Existing Mods</h2>
   <div id="mods" class="mod-list"></div>
+
   <script>
-    fetch('/api/mods-all')
-      .then(res => res.json())
-      .then(mods => {
-        const container = document.getElementById('mods');
-        mods.forEach(mod => {
-          const div = document.createElement('div');
-          div.className = 'mod-item';
-          div.innerHTML = `<h3>${mod.name} <small>${mod.version ? mod.version : ''}</small></h3>` +
-            `<p>${mod.description ? mod.description : ''}</p>`;
-          container.appendChild(div);
+    function appendMod(mod) {
+      const container = document.getElementById('mods');
+      const div = document.createElement('div');
+      div.className = 'mod-item';
+      div.innerHTML = `<h3>${mod.name} <small>${mod.version ? mod.version : ''}</small></h3>` +
+        `<p>${mod.description ? mod.description : ''}</p>`;
+      container.appendChild(div);
+    }
+
+    function loadMods() {
+      fetch('/api/mods-all')
+        .then(res => res.json())
+        .then(mods => {
+          document.getElementById('mods').innerHTML = '';
+          mods.forEach(appendMod);
+        })
+        .catch(err => {
+          document.getElementById('mods').textContent = 'Failed to load mods.';
+          console.error('Error loading mods', err);
         });
+    }
+
+    document.getElementById('mod-form').addEventListener('submit', function (e) {
+      e.preventDefault();
+      const data = {
+        name: document.getElementById('name').value,
+        version: document.getElementById('version').value,
+        description: document.getElementById('description').value,
+      };
+      fetch('/api/mods', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(data)
       })
-      .catch(err => {
-        document.getElementById('mods').textContent = 'Failed to load mods.';
-        console.error('Error loading mods', err);
-      });
+        .then(res => res.json())
+        .then(mod => {
+          appendMod(mod);
+          document.getElementById('mod-form').reset();
+        })
+        .catch(err => console.error('Error creating mod', err));
+    });
+
+    loadMods();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow creating mods through POST `/mods`
- add form and navigation in `index.html`
- document new functionality in README

## Testing
- `npm test` *(fails: package.json missing)*
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851b02378e48327a916fed773d8fa2c